### PR TITLE
Adjusted to work with new validator results return.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
-  "name": "tesla-light-show-validator",
+  "name": "vue-tlsv",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "tesla-light-show-validator",
+      "name": "vue-tlsv",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@xsor/tlsv": "^0.0.1-alpha.0",
+        "@xsor/tlsv": "0.2.1",
         "compression": "^1.7.4",
         "express": "^4.17.2"
       },
@@ -2856,9 +2856,12 @@
       }
     },
     "node_modules/@xsor/tlsv": {
-      "version": "0.0.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/@xsor/tlsv/-/tlsv-0.0.1-alpha.0.tgz",
-      "integrity": "sha512-E3//9hHvO+usX5evd9i5KU8tHDapQhiP9Br7GUv7tslqQvuKXSIK0gXoDPY3QjVqPJDMLLq3+gKJ+QEdDWreqg=="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@xsor/tlsv/-/tlsv-0.2.1.tgz",
+      "integrity": "sha512-ziAsjMZcj7Gw5O6ImVv/YcDqgLTNGGAx4XaQ/mDTz4csgfqAgaZKHi65bJtd3D6mRYJuWuDbWPuwhDyz0qhtGA==",
+      "bin": {
+        "tlsv": "dist/cjs/cli.js"
+      }
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
@@ -18938,9 +18941,9 @@
       }
     },
     "@xsor/tlsv": {
-      "version": "0.0.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/@xsor/tlsv/-/tlsv-0.0.1-alpha.0.tgz",
-      "integrity": "sha512-E3//9hHvO+usX5evd9i5KU8tHDapQhiP9Br7GUv7tslqQvuKXSIK0gXoDPY3QjVqPJDMLLq3+gKJ+QEdDWreqg=="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@xsor/tlsv/-/tlsv-0.2.1.tgz",
+      "integrity": "sha512-ziAsjMZcj7Gw5O6ImVv/YcDqgLTNGGAx4XaQ/mDTz4csgfqAgaZKHi65bJtd3D6mRYJuWuDbWPuwhDyz0qhtGA=="
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "main": "express.js",
   "dependencies": {
-    "@xsor/tlsv": "^0.0.1-alpha.0",
+    "@xsor/tlsv": "0.2.1",
     "compression": "^1.7.4",
     "express": "^4.17.2"
   },

--- a/src/components/Validator.vue
+++ b/src/components/Validator.vue
@@ -63,6 +63,13 @@
 import { Validator } from '@xsor/tlsv';
 import Disclaimer from '@/components/Disclaimer';
 
+// Those mappings must be the same as defined in the '@xsor/tlsv' module.
+const FileFormat = 1
+const ChannelCount = 2
+const FseqType = 3
+const Duration = 4
+const Memory = 5
+
 export default {
   name: 'Validator',
   components: {Disclaimer},
@@ -120,8 +127,8 @@ export default {
 
       let anyErrorExists = false;
 
-      if (resultsKeys.includes('4')) {
-        let durationResults = validation.results[4];
+      if (resultsKeys.includes(Duration.toString())) {
+        let durationResults = validation.results[Duration];
         if (durationResults.isValid) {
           let durationFormatted = new Date(validation.duration * 1000).toISOString().substr(11, 12);
           this.durationAlertType = 'success';
@@ -133,8 +140,8 @@ export default {
         }
       }
 
-      if (resultsKeys.includes('5')) {
-        let memoryResults = validation.results[5];
+      if (resultsKeys.includes(Memory.toString())) {
+        let memoryResults = validation.results[Memory];
         if (memoryResults.isValid) {
           const memoryUsage = parseFloat((validation.memoryUsage * 100).toFixed(2));
           this.memoryAlertType = 'success';
@@ -147,7 +154,7 @@ export default {
       }
 
       resultsKeys.forEach(function(key) {
-        if (['1', '2', '3'].includes(key)) {
+        if ([FileFormat.toString(), ChannelCount.toString(), FseqType.toString()].includes(key)) {
           let value = validation.results[key];
           console.log(value)
           if (!value.isValid) {


### PR DESCRIPTION
Those are the adjustments to reflect the changes made to 'tlsv' in [this](https://github.com/xsorifc28/tlsv/pull/1) pull request.

## Additional changes
- Previously the following errors wouldn't be shown if they occurred: 'wrong file format', 'wrong channel count' and 'wrong compression type'. If you try to upload a .fseq file with the `V2 ZSTD` FSEQ type, then currently it comes to weird behavior on the website due to the javascript method crashing. This PR also fixes this issues (which was the original reason why I updated the whole error return thing) by introducing a new field on the website for 'other errors'.